### PR TITLE
Now it works when video id is not the first parameter in youtube URL

### DIFF
--- a/lib/video_thumb.rb
+++ b/lib/video_thumb.rb
@@ -37,9 +37,9 @@ module VideoThumb
       youtube_size  = 'sddefault'
       vimeo_size    = 'thumbnail_large'
     end
-
+    
     if url.include?('youtu.be') || url.include?('youtube')
-      regex = /(https?:\/\/)?(www.)?(youtube\.com\/watch\?v=|youtu\.be\/|youtube\.com\/watch\?feature=player_embedded&v=)([A-Za-z0-9_-]*)(\&\S+)?(\?\S+)?/
+      regex = /(https?:\/\/)?(www.)?(youtube\.com\/watch\?v=|youtu\.be\/|youtube\.com\/watch\?[A-Za-z0-9_=-]+&v=)([A-Za-z0-9_-]*)(\&\S+)?(\?\S+)?/
       url.gsub(regex) do
         youtube_video_id = $4
         image = "https://img.youtube.com/vi/#{youtube_video_id}/#{youtube_size}.jpg"

--- a/test/video_thumb_test.rb
+++ b/test/video_thumb_test.rb
@@ -11,4 +11,7 @@ class VideoThumbTest < Minitest::Test
   def test_secure_vimeo_video
     assert_equal "http://i.vimeocdn.com/video/483188148_640.jpg", VideoThumb::get("https://vimeo.com/101419884")
   end
+  def test_reversed_url_params
+    assert_equal "https://img.youtube.com/vi/9BOuRUlRKzA/sddefault.jpg", VideoThumb::get("https://www.youtube.com/watch?time_continue=3&v=9BOuRUlRKzA")
+  end
 end


### PR DESCRIPTION
Before, the gem supported only "feature=player_embedded" as the first parameter but I had a problem with another one being in the first position. I guess this is more flexible solution.