### PR TITLE
Use HTTPS for vimeo

### DIFF
--- a/lib/video_thumb.rb
+++ b/lib/video_thumb.rb
@@ -53,7 +53,7 @@ module VideoThumb
         url = get_redirect_url(url) unless regex.match?(url)
         url.gsub(regex) do
           vimeo_video_id = Regexp.last_match(2)
-          vimeo_video_json_url = format('http://vimeo.com/api/v2/video/%s.json', vimeo_video_id)
+          vimeo_video_json_url = format('https://vimeo.com/api/v2/video/%s.json', vimeo_video_id)
           image = begin
                     JSON.parse(URI.open(vimeo_video_json_url).read).first[vimeo_size]
                   rescue StandardError

--- a/test/video_thumb_test.rb
+++ b/test/video_thumb_test.rb
@@ -7,15 +7,15 @@ class VideoThumbTest < Minitest::Test
   end
 
   def test_vimeo_video
-    assert_equal 'http://i.vimeocdn.com/video/483188148_640.jpg', VideoThumb.get('http://vimeo.com/101419884')
+    assert_equal 'https://i.vimeocdn.com/video/483188148_640.jpg', VideoThumb.get('http://vimeo.com/101419884')
   end
 
   def test_secure_vimeo_video
-    assert_equal 'http://i.vimeocdn.com/video/483188148_640.jpg', VideoThumb.get('https://vimeo.com/101419884')
+    assert_equal 'https://i.vimeocdn.com/video/483188148_640.jpg', VideoThumb.get('https://vimeo.com/101419884')
   end
 
   def test_aliased_vimeo_video
-    assert_equal 'http://i.vimeocdn.com/video/699818221_640.jpg', VideoThumb.get('https://vimeo.com/madeinyuhara/watasinoinaihoshi')
+    assert_equal 'https://i.vimeocdn.com/video/699818221_640.jpg', VideoThumb.get('https://vimeo.com/madeinyuhara/watasinoinaihoshi')
   end
 
   def test_reversed_url_params


### PR DESCRIPTION
The vimeo API url uses HTTP right now, which is potentially insecure. I've upgraded it to use HTTPS instead.