### PR TITLE
Update vimeo test result urls

### DIFF
--- a/test/video_thumb_test.rb
+++ b/test/video_thumb_test.rb
@@ -7,15 +7,15 @@ class VideoThumbTest < Minitest::Test
   end
 
   def test_vimeo_video
-    assert_equal 'http://i.vimeocdn.com/video/483188148_640.jpg', VideoThumb.get('http://vimeo.com/101419884')
+    assert_equal 'http://i.vimeocdn.com/video/483188148-c2e6e58357c4d88f05c53949868a19ff76d7237f71f48947dd0b28276ab3d61b-d_640', VideoThumb.get('http://vimeo.com/101419884')
   end
 
   def test_secure_vimeo_video
-    assert_equal 'http://i.vimeocdn.com/video/483188148_640.jpg', VideoThumb.get('https://vimeo.com/101419884')
+    assert_equal 'http://i.vimeocdn.com/video/483188148-c2e6e58357c4d88f05c53949868a19ff76d7237f71f48947dd0b28276ab3d61b-d_640', VideoThumb.get('https://vimeo.com/101419884')
   end
 
   def test_aliased_vimeo_video
-    assert_equal 'http://i.vimeocdn.com/video/699818221_640.jpg', VideoThumb.get('https://vimeo.com/madeinyuhara/watasinoinaihoshi')
+    assert_equal 'http://i.vimeocdn.com/video/699818221-17cfe596d47c3751e58295209cb575361fc964f385b9be553834b19345dcae4a-d_640', VideoThumb.get('https://vimeo.com/madeinyuhara/watasinoinaihoshi')
   end
 
   def test_reversed_url_params


### PR DESCRIPTION
At some point vimeo has changed it's thumbnail urls to be much longer, so the current tests fail. I've updated them with the current URLs for these videos.