### PR TITLE
Only catch openuri errors

### DIFF
--- a/lib/video_thumb.rb
+++ b/lib/video_thumb.rb
@@ -56,7 +56,7 @@ module VideoThumb
           vimeo_video_json_url = format('http://vimeo.com/api/v2/video/%s.json', vimeo_video_id)
           image = begin
                     JSON.parse(URI.open(vimeo_video_json_url).read).first[vimeo_size]
-                  rescue StandardError
+                  rescue OpenURI::HTTPError
                     nil
                   end
           return image


### PR DESCRIPTION
By catching standard error we mask a lot of valid errors and silently return nil. This can make it difficult to debug issues in production apps and in tests.

Instead I've made the code only catch openuri http errors. This might not catch every kind of network error but I think that's better than silently swallowing valid errors.